### PR TITLE
Bump to 0.1.4 and clean up specfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # CentOS 7 RPM Specfile for ocaml-samplerate
 
-This repository contains the specfile for ocaml-samplerate which is part of the [RaBe liquidsoap distribution](https://build.opensuse.org/project/show/home:radiorabe:liquidsoap).
+This repository contains the specfile for [ocaml-samplerate](https://github.com/savonet/ocaml-samplerate) which is part of the [RaBe liquidsoap distribution](https://build.opensuse.org/project/show/home:radiorabe:liquidsoap).
 
 ## Usage
 
 ```bash
-yum install http://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/CentOS_7/home:radiorabe:liquidsoap.repo
+yum install \
+  https://download.opensuse.org/repositories/home:/radiorabe:/liquidsoap/CentOS_7/home:radiorabe:liquidsoap.repo
+
 yum install ocaml-samplerate
 ```

--- a/ocaml-samplerate.spec
+++ b/ocaml-samplerate.spec
@@ -1,24 +1,41 @@
 Name:     ocaml-samplerate
-
-Version:  0.1.3
-Release:  1
+Version:  0.1.4
+Release:  1%{?dist}
 Summary:  OCaml bindings for the libsamplerate
+
+%global libname %(echo %{name} | sed -e 's/^ocaml-//')
+
 License:  GPLv2+
 URL:      https://github.com/savonet/ocaml-samplerate
-Source0:  https://github.com/savonet/ocaml-samplerate/releases/download/0.1.3/ocaml-samplerate-0.1.3.tar.gz
+Source0:  https://github.com/savonet/%{name}/releases/download/%{version}/%{name}-%{version}.tar.gz
+
 
 BuildRequires: ocaml
 BuildRequires: ocaml-findlib
 BuildRequires: libsamplerate-devel
 Requires:      libsamplerate
 
+
+%description
+OCAML bindings for libsamplerate based on based on Madlld example.
+
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and signature
+files for developing applications that use %{name}.
+
+
 %prep
-%setup -q 
+%autosetup -n %{name}-%{version}
 
 %build
 ./configure \
    --prefix=%{_prefix} \
-   -disable-ldconf
+   --disable-ldconf
 make all
 
 %install
@@ -31,20 +48,29 @@ install -d $OCAMLFIND_DESTDIR/%{ocamlpck}
 make install
 
 %files
-/usr/lib64/ocaml/samplerate/META
-/usr/lib64/ocaml/samplerate/dllsamplerate_stubs.so
-/usr/lib64/ocaml/samplerate/libsamplerate_stubs.a
-/usr/lib64/ocaml/samplerate/samplerate.a
-/usr/lib64/ocaml/samplerate/samplerate.cma
-/usr/lib64/ocaml/samplerate/samplerate.cmi
-/usr/lib64/ocaml/samplerate/samplerate.cmx
-/usr/lib64/ocaml/samplerate/samplerate.cmxa
-/usr/lib64/ocaml/samplerate/samplerate.mli
+%doc README
+%license COPYING
+%{_libdir}/ocaml/%{libname}
+%ifarch %{ocaml_native_compiler}
+%exclude %{_libdir}/ocaml/%{libname}/*.a
+%exclude %{_libdir}/ocaml/%{libname}/*.cmxa
+%exclude %{_libdir}/ocaml/%{libname}/*.cmx
+%exclude %{_libdir}/ocaml/%{libname}/*.mli
+%endif
 
-%description
-OCAML bindings for the libsamplerate based on based on Madlld example.
-
+%files devel
+%license COPYING
+%ifarch %{ocaml_native_compiler}
+%{_libdir}/ocaml/%{libname}/*.a
+%{_libdir}/ocaml/%{libname}/*.cmxa
+%{_libdir}/ocaml/%{libname}/*.cmx
+%{_libdir}/ocaml/%{libname}/*.mli
+%endif
 
 %changelog
-* Sun Jul  3 2016 Lucas Bickel <hairmare@rabe.ch>
+* Sun Dec  9 2018 Lucas Bickel <hairmare@rabe.ch> - 0.1.4-1
+- Bump to 0.1.4
+- Cleanup specfile and create -devel subpackage
+
+* Sun Jul  3 2016 Lucas Bickel <hairmare@rabe.ch> - 0.1.3-1
 - initial version, mostly stolen from https://www.openmamba.org/showfile.html?file=/pub/openmamba/devel/specs/ocaml-samplerate.spec


### PR DESCRIPTION
This will lead to the main liquidsoap package breaking but there are more than just this package that need a clean up before fixing the main liquidsoap binary makes sense.